### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,7 @@
     "language": "python",
     "library_type": "OTHER",
     "repo": "googleapis/python-test-utils",
-    "distribution_name": "google-cloud-testutils"
-}  
+    "distribution_name": "google-cloud-testutils",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114
