### PR TITLE
feat: add support for `test_utils.__version__`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,17 @@
 
 import io
 import os
+import re
 import setuptools  # type: ignore
 
-version = "1.5.0"
+version = None
+
+PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(PACKAGE_ROOT, "test_utils/version.py")) as fp:
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert len(version_candidates) == 1
+    version = version_candidates[0]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-from .version import __version__
+from .version import __version__  # noqa: F401

--- a/test_utils/version.py
+++ b/test_utils/version.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from .version import __version__
+__version__ = "1.5.0"


### PR DESCRIPTION
Similar to https://github.com/googleapis/proto-plus-python/pull/393

This PR migrates from using a hardcoded version in `setup.py` to a version module to make it easy to query the current version of `test_utils`

```
partheniou@partheniou-vm-3:~/git/python-test-utils$ python3
Python 3.9.16 (main, Mar  2 2023, 17:52:22) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import test_utils
>>> test_utils.__version__
'1.5.0'
```