### PR TITLE
chore: librarian release pull request: 20251113T213832Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-cloud-testutils
-    version: 1.7.0
+    version: 1.8.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-testutils/#history
 
+## [1.8.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-testutils-v1.7.0...google-cloud-testutils-v1.8.0) (2025-11-13)
+
+
+### Features
+
+* some feature ([16a0385436d324d4568df4786dbd174042c8622d](https://github.com/googleapis/google-cloud-python/commit/16a0385436d324d4568df4786dbd174042c8622d))
+
 ## [1.7.0](https://github.com/googleapis/python-test-utils/compare/v1.6.4...v1.7.0) (2025-10-29)
 
 

--- a/test_utils/version.py
+++ b/test_utils/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.7.0"
+__version__ = "1.8.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-cloud-testutils: 1.8.0</summary>

## [1.8.0](https://github.com/googleapis/python-test-utils/compare/v1.7.0...v1.8.0) (2025-11-13)

### Features

* some feature ([16a03854](https://github.com/googleapis/python-test-utils/commit/16a03854))

</details>