### PR TITLE
chore(tests): update kokoro continuous test config

### DIFF
--- a/.kokoro/continuous/continuous.cfg
+++ b/.kokoro/continuous/continuous.cfg
@@ -1,1 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+  key: "NOX_SESSION"
+  value: "blacken mypy check_lower_bounds"
+}


### PR DESCRIPTION
The continuous kokoro test should use the [same configuration as the pre-submit](https://github.com/googleapis/python-test-utils/blob/main/.kokoro/presubmit/presubmit.cfg)
